### PR TITLE
Feat(Server): Set initial server structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# unit tests
+test:
+	go test -v ./...
+
+run:
+	go run main.go

--- a/dat/locations.go
+++ b/dat/locations.go
@@ -1,0 +1,30 @@
+package dat
+
+import "github.com/etzba/pggo/wire"
+
+func GetLocations() []wire.Location {
+	locations := []wire.Location{
+		{
+			Id:         1,
+			Name:       "",
+			Address:    "",
+			Longtitude: 56.342155413,
+			Latitude:   18.123876123,
+		},
+		{
+			Id:         2,
+			Name:       "",
+			Address:    "",
+			Longtitude: 56.342155413,
+			Latitude:   18.123876123,
+		},
+		{
+			Id:         3,
+			Name:       "",
+			Address:    "",
+			Longtitude: 56.342155413,
+			Latitude:   18.123876123,
+		},
+	}
+	return locations
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/etzba/pggo
+
+go 1.22.4
+
+require github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/etzba/pggo/pkg/logger"
+	"github.com/etzba/pggo/server"
+)
+
+func main() {
+	logger := logger.New()
+	server := server.New(logger, ":8080")
+	if err := server.Run(); err != nil {
+		panic(err)
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,74 @@
+openapi: 3.0.0
+
+info:
+  title: Etzba api test server
+  description: This server will help to test etzba cli tool with several endpoints and databases and other tools, to measure performance and load testing
+  version: 1.0.0
+
+servers:
+  - url: http://api.etzba.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://development-api.etzba.com
+    description: Optional server description, e.g. Internal development server for testing
+
+paths:
+  /locations:
+    get:
+      summary: Returns a list of results.
+      description: Optional extended description in CommonMark or HTML.
+      etzba: true
+      responses:
+        '200':    # status code
+          description: A JSON array of results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Result'
+  /locations/{locationId}:
+    get:
+      summary: Returns a result by ID.
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          description: Parameter description in CommonMark or HTML.
+      responses:
+        '200':
+          description: Get a location by ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    format: int64
+                    example: 4
+                  created:
+                    type: string
+                    format: date # or date-time
+                    example: "2200-01-01T13:09:35.835Z"
+                    pattern: "YYYY-MM-DD"
+                  modified:
+                    type: string
+                    format: date # or date-time
+                    example: "2200-01-01T13:09:35.835Z"
+                    pattern: "YYYY-MM-DD"
+                  name:
+                    type: string
+                    example: "kenman"
+                    minLength: 3
+                    maxLength: 5
+                  address:
+                    type: string
+                    example: "Ilivein street 32, Dillton 14532"
+                    minLength: 12
+                    maxLength: 48
+                  longtitude: 
+                    type: number
+                    format: float
+                    example: 89.0653450122
+                  latitudes: 
+                    type: number
+                    format: float
+                    example: 12.6682134654

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"fmt"
+	"time"
+)
+
+type Logger interface {
+	Info(msg string)
+	Error(msg string)
+}
+
+type Log struct {
+}
+
+func New() *Log {
+	return &Log{}
+}
+
+func (l *Log) Info(msg string) {
+	fmt.Println("INFO", time.Now().UTC(), msg)
+}
+
+func (l *Log) Error(msg string, err error) {
+	fmt.Println("ERROR", time.Now().UTC(), msg, err.Error())
+}

--- a/server/api_locations.go
+++ b/server/api_locations.go
@@ -1,0 +1,17 @@
+package server
+
+import "net/http"
+
+func (s *Server) getLocations() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.Logger.Info("Server go request" + " method: " + r.Method + " uri: " + r.RequestURI)
+		s.Respoder.SendOK(w)
+	}
+}
+
+func (s *Server) getLocationById() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.Logger.Info("Server go request" + " method: " + r.Method + " uri: " + r.RequestURI)
+		s.Respoder.SendOK(w)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/etzba/pggo/pkg/logger"
+	"github.com/etzba/pggo/wire"
+	"github.com/gorilla/mux"
+)
+
+type Server struct {
+	Logger     *logger.Log
+	HTTPServer *http.Server
+	Mux        *http.ServeMux
+	Respoder   wire.Responder
+}
+
+func New(logger *logger.Log, address string) *Server {
+	responder := wire.Respond{
+		Logger: logger,
+	}
+	server := &Server{
+		Logger:   logger,
+		Respoder: responder,
+	}
+	router := server.getRouter()
+	server.Mux = http.NewServeMux()
+	server.Mux.Handle("/", router)
+	server.HTTPServer = &http.Server{
+		Addr:    address,
+		Handler: router,
+	}
+	return server
+}
+
+func (s *Server) Run() error {
+	s.Logger.Info("Start server in port 8080")
+	if err := s.HTTPServer.ListenAndServe(); err != nil {
+		s.Logger.Error("cannot run http server - listen and serve", err)
+	}
+	return nil
+}
+
+func (s *Server) getRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.HandleFunc("/locations", s.getLocations()).Methods("GET")
+	router.HandleFunc("/locations/{id}", s.getLocationById()).Methods("GET")
+	return router
+}

--- a/wire/locations.go
+++ b/wire/locations.go
@@ -1,0 +1,9 @@
+package wire
+
+type Location struct {
+	Id         int     `json:"id"`
+	Name       string  `json:"name"`
+	Address    string  `json:"address"`
+	Longtitude float64 `json:"longtitude"`
+	Latitude   float64 `json:"latitude"`
+}

--- a/wire/responder.go
+++ b/wire/responder.go
@@ -1,0 +1,20 @@
+package wire
+
+import (
+	"net/http"
+
+	"github.com/etzba/pggo/pkg/logger"
+)
+
+type Responder interface {
+	SendOK(w http.ResponseWriter)
+}
+
+type Respond struct {
+	Logger *logger.Log
+}
+
+func (r Respond) SendOK(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK!"))
+}


### PR DESCRIPTION
### Context
Create and run http server.

### Description
Run the server by using Makefile
```
$ make run
go run main.go
INFO 2024-08-23 22:39:59.431379934 +0000 UTC Start server in port 8080
INFO 2024-08-23 22:40:01.849726593 +0000 UTC Server go request method: GET uri: /locations
INFO 2024-08-23 22:40:06.208091923 +0000 UTC Server go request method: GET uri: /locations
INFO 2024-08-23 22:40:14.477961251 +0000 UTC Server go request method: GET uri: /locations/2
INFO 2024-08-23 22:40:18.896400654 +0000 UTC Server go request method: GET uri: /locations/3
```
Test by running curl:
```
$ curl http://localhost:8080/locations/3 -v
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /locations/3 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Fri, 23 Aug 2024 22:40:18 GMT
< Content-Length: 3
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
OK!
```